### PR TITLE
Allow passing printHelpOnEmptyArgs to ArgParser

### DIFF
--- a/core/commonMain/src/ArgParser.kt
+++ b/core/commonMain/src/ArgParser.kt
@@ -103,7 +103,8 @@ open class ArgParser(
     var useDefaultHelpShortName: Boolean = true,
     var prefixStyle: OptionPrefixStyle = OptionPrefixStyle.LINUX,
     var skipExtraArguments: Boolean = false,
-    var strictSubcommandOptionsOrder: Boolean = false
+    var strictSubcommandOptionsOrder: Boolean = false,
+    var printHelpOnEmptyArgs: Boolean = false
 ) {
 
     /**
@@ -531,6 +532,10 @@ open class ArgParser(
 
     protected fun parse(args: List<String>): ArgParserResult {
         check(parsingState == null) { "Parsing of command line options can be called only once." }
+        
+        if (args.isEmpty() && printHelpOnEmptyArgs) {
+            outputAndTerminate(makeUsage(), 0)
+        }
 
         // Add help option.
         val helpDescriptor = if (useDefaultHelpShortName) OptionDescriptor<Boolean, Boolean>(


### PR DESCRIPTION
This makes it easier to use the commands, cause it will print the help text when you set printHelpOnEmptyArgs = true